### PR TITLE
add password validation script for mqtt|wifi.html

### DIFF
--- a/Code/6-wire-version/data/function.js
+++ b/Code/6-wire-version/data/function.js
@@ -16,3 +16,12 @@ function togglePlainText(id) {
         x.type = "password";
     }
 }
+
+function validatePassword(id) {
+    var x = document.getElementById(id);
+    if (x.value == "<enter password>") {
+        alert("Please enter a password to continue.");
+		return false;
+    }
+    return true;
+}

--- a/Code/6-wire-version/data/mqtt.html
+++ b/Code/6-wire-version/data/mqtt.html
@@ -102,6 +102,8 @@ function loadConfig()
 
 function saveConfig()
 {
+	if (!validatePassword('mqttPassword')) return;
+	
 	const Http = new XMLHttpRequest();
 	const url='/setmqtt/';
 	Http.open("POST", url);

--- a/Code/6-wire-version/data/wifi.html
+++ b/Code/6-wire-version/data/wifi.html
@@ -175,6 +175,8 @@ function loadConfig()
 
 function saveConfig()
 {
+	if (!validatePassword('apPwd')) return;
+
 	const Http = new XMLHttpRequest();
 	const url='/setwifi/';
 	Http.open("POST", url);

--- a/Code/6-wire-version/src/main.cpp
+++ b/Code/6-wire-version/src/main.cpp
@@ -34,6 +34,7 @@ void setup()
   // needs to be loaded here for reading the wifi.json
   LittleFS.begin();
   loadWifi();
+  
   startWiFi();
   startNTP();
   startOTA();
@@ -838,8 +839,6 @@ void handleResetWifi()
   Serial.println(F("ESP reset ..."));
   ESP.reset();
 }
-
-
 
 /**
  * load MQTT json configuration from "mqtt.json"


### PR DESCRIPTION
this change prevents a standard password from being submitted

```
main.cpp
- doc["apPwd"] = "<enter password>";
- doc["mqttPassword"] = "<enter password>";

function.js
- if (x.value == "<enter password>")
```