### PR TITLE
Added a true "Status" Binary Sensor for HA

### DIFF
--- a/Code/Home assistant config/binary-sensors.yaml
+++ b/Code/Home assistant config/binary-sensors.yaml
@@ -49,3 +49,13 @@
   payload_not_available: "Dead"
   expire_after: 700
 
+- platform: mqtt 
+  name: Spa Status
+  device_class: connectivity
+  entity_category: diagnostic
+  state_topic: "BW_2.0.0/Status" 
+  availability_topic: "BW_2.0.0/Status"
+  payload_available: "Alive" 
+  payload_not_available: "Dead"
+  payload_on: "Alive" 
+  payload_off: "Dead"


### PR DESCRIPTION
Added a default Home Assistant "Status" / Connectivity status binary sensor. This has been added with entity classes so it's added to the correct parts of HA if we ever get the DEVICE added - Status is "device_class: connectivity" and "entity_category: diagnostic". Home assistant does the rest and sets the icon, changes it on up/down, and the payload_on/payload_off sets the correct state to Connected/Disconnected.