### PR TITLE
Add timestamp to STATES MQTT messages in `/message` topic

### DIFF
--- a/Code/4-wire-version/lib/BWC4W/BWC_8266_4w.cpp
+++ b/Code/4-wire-version/lib/BWC4W/BWC_8266_4w.cpp
@@ -430,6 +430,7 @@ String BWC::getJSONStates() {
 
     // Set the values in the document
     doc["CONTENT"] = "STATES";
+    doc["TIME"] = _timestamp;
     doc["LCK"] = _cio.states[LOCKEDSTATE];
     doc["PWR"] = _cio.states[POWERSTATE];
     doc["UNT"] = _cio.states[UNITSTATE];


### PR DESCRIPTION
This PR adds a timestamp in the `TIME` field of messages sent to the `/message` topic.

I've seen the comment about [backward compatibility](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/blob/v3.1.0/Code/4-wire-version/src/main.cpp#L207), but this shouldn't break anything if JSON messages are properly parsed by consumers.

Should this also be done for the 6-wire variant?