### PR TITLE
4 Wire Error State based on character display

### DIFF
--- a/Code/Home assistant config/binary-sensors.yaml
+++ b/Code/Home assistant config/binary-sensors.yaml
@@ -59,3 +59,16 @@
   payload_not_available: "Dead"
   payload_on: "Alive" 
   payload_off: "Dead"
+
+  # 4 Wire Error State based on character display [E00]
+- platform: mqtt 
+  name: Spa Error
+  device_class: problem
+  entity_category: diagnostic
+  state_topic: "layzspa/message"
+  value_template: "{{ value_json.CH1 }}"
+  availability_topic: "layzspa/Status"
+  payload_available: "Alive" 
+  payload_not_available: "Dead"
+  payload_on: 69 
+  payload_off: 48


### PR DESCRIPTION
4 Wire Error State based on character display [E00] when the unit shows an error. 

6-wire and dev has an ERR flag, but the master branch does not have this yet. This binary sensor can be used for 4-wire units that flag up the first character changes from 0 to E.