### PR TITLE
Add fan (pump only) option to the MQTT HVAC 

### DIFF
--- a/Code/6-wire-version/src/main.cpp
+++ b/Code/6-wire-version/src/main.cpp
@@ -2129,7 +2129,7 @@ void setupClimate()
   doc["temperature_command_template"] = F("{CMD:0,VALUE:{{ value|int }},XTIME:0,INTERVAL:0}");
   doc["power_command_topic"] = mqttBaseTopic+F("/command");
   doc["payload_on"] = F("{CMD:3,VALUE:1,XTIME:0,INTERVAL:0}");
-  doc["payload_off"] = F("{CMD:3,VALUE:0,XTIME:0,INTERVAL:0}");
+  doc["payload_off"] = F("{CMD:4,VALUE:0,XTIME:0,INTERVAL:0}");
   doc["availability_topic"] = mqttBaseTopic+F("/Status");
   doc["payload_available"] = F("Alive");
   doc["payload_not_available"] = F("Dead");

--- a/Code/6-wire-version/src/main.cpp
+++ b/Code/6-wire-version/src/main.cpp
@@ -2116,11 +2116,13 @@ void setupClimate()
   doc["min_temp"] = mintemp;
   doc["precision"] = 1.0;
   doc["temperature_unit"] = tempunit;
-  doc["modes"].add(serialized("\"off\", \"heat\""));
+  doc["modes"].add(serialized("\"fan_only\", \"off\", \"heat\""));
+  doc["mode_command_topic"] = mqttBaseTopic+F("/command");
+  doc["mode_command_template"] = F("{CMD:3,VALUE:{%if value == \"heat\" %}1{% else %}0{% endif %},XTIME:0,INTERVAL:0}");
   doc["mode_state_topic"] = mqttBaseTopic+F("/message");
   doc["mode_state_template"] = F("{% if value_json.RED == 1 %}heat{% elif value_json.GRN == 1 %}heat{% else %}off{% endif %}");
   doc["action_topic"] = mqttBaseTopic+F("/message");
-  doc["action_template"] = F("{% if value_json.RED == 1 %}heating{% elif value_json.GRN == 1 %}idle{% else %}off{% endif %}");
+  doc["action_template"] = F("{% if value_json.RED == 1 %}heating{% elif value_json.GRN == 1 %}idle{% elif value_json.FLT == 1 %}fan{% else %}off{% endif %}");
   doc["temperature_state_topic"] = mqttBaseTopic+F("/message");
   doc["temperature_state_template"] = F("{{ value_json.TGT }}");
   doc["current_temperature_topic"] = mqttBaseTopic+F("/message");
@@ -2128,7 +2130,7 @@ void setupClimate()
   doc["temperature_command_topic"] = mqttBaseTopic+F("/command");
   doc["temperature_command_template"] = F("{CMD:0,VALUE:{{ value|int }},XTIME:0,INTERVAL:0}");
   doc["power_command_topic"] = mqttBaseTopic+F("/command");
-  doc["payload_on"] = F("{CMD:3,VALUE:1,XTIME:0,INTERVAL:0}");
+  doc["payload_on"] = F("{CMD:4,VALUE:1,XTIME:0,INTERVAL:0}");
   doc["payload_off"] = F("{CMD:4,VALUE:0,XTIME:0,INTERVAL:0}");
   doc["availability_topic"] = mqttBaseTopic+F("/Status");
   doc["payload_available"] = F("Alive");


### PR DESCRIPTION
Implements pump only as the fan option:
![image](https://user-images.githubusercontent.com/1091420/167229008-81eb3518-2b00-429f-828d-8f7788ed3997.png)

Heat switches between heating and idle as before
Fan only runs the pump, heating is off
Off actually shuts down the pump and heating 

Useful for recirculating the water for example but preventing the pump to run all day in HA scheduler, etc (instead of individual switching the pump):
![image](https://user-images.githubusercontent.com/1091420/167229159-3f5529b3-b475-4d1f-853e-f968a4eac9ea.png)
