### PR TITLE
Added a command_batch topic for multiple commands

### DIFF
--- a/Code/4-wire-version/src/main.cpp
+++ b/Code/4-wire-version/src/main.cpp
@@ -1384,8 +1384,6 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
     bwc.qCommand(command, value, xtime, interval);
   }
 
-  
-
   if (String(topic).equals(String(mqttBaseTopic) + "/command_batch"))
   {
     DynamicJsonDocument doc(1024);

--- a/Code/4-wire-version/src/main.cpp
+++ b/Code/4-wire-version/src/main.cpp
@@ -1383,6 +1383,29 @@ void mqttCallback(char* topic, byte* payload, unsigned int length)
     int64_t interval = doc["INTERVAL"];
     bwc.qCommand(command, value, xtime, interval);
   }
+
+  
+
+  if (String(topic).equals(String(mqttBaseTopic) + "/command_batch"))
+  {
+    DynamicJsonDocument doc(1024);
+    String message = (const char *) &payload[0];
+    DeserializationError error = deserializeJson(doc, message);
+    if (error)
+    {
+      return;
+    }
+
+    JsonArray commandArray = doc.as<JsonArray>();
+
+    for (JsonVariant commandItem : commandArray) {
+        int64_t command = commandItem["CMD"];
+        int64_t value = commandItem["VALUE"];
+        int64_t xtime = commandItem["XTIME"];
+        int64_t interval = commandItem["INTERVAL"];
+        bwc.qCommand(command, value, xtime, interval);
+    }
+  }
 }
 
 /**
@@ -1422,6 +1445,7 @@ void mqttConnect()
 
     // Watch the 'command' topic for incoming MQTT messages
     mqttClient.subscribe((String(mqttBaseTopic) + "/command").c_str());
+    mqttClient.subscribe((String(mqttBaseTopic) + "/command_batch").c_str());
     mqttClient.loop();
 
     mqttClient.publish((String(mqttBaseTopic) + "/reboot_time").c_str(), bwc.reboottime.c_str(), true);


### PR DESCRIPTION
Hi,

i've added a new topic to the mqtt subscriptions wich is names command_batch.

There you can send multiple commands in as an array and they will be added to the que.

i use this to set multiple things at the same time.

for example i want to deactivate the heater and activate the filter or deactivate both at the same time.

Greetings Malfurion