### PR TITLE
Add feature to override power usages

### DIFF
--- a/Code/data/hwconfig.html
+++ b/Code/data/hwconfig.html
@@ -147,6 +147,35 @@
 		</section>
 
 		<section>
+			<p>Power levels (in Watts) <span data-text="Customize power levels for different running modes." class="tooltip">?</span></p>
+			<table>
+				<tr>
+					<td colspan="5">Override <input type="checkbox" id="pwr_override" onclick="onOverrideClick()"></td>
+				</tr>
+				<tr>
+					<td>Heat stage 1<input type="text" id="pwr_heater_stage1" maxlength="4" style="width:30px" 
+						inputmode="numeric" pattern="[0-9]{1,4}"
+						disabled="disabled"></td>
+					<td>Heat stage 2<input type="text" id="pwr_heater_stage2" maxlength="4" style="width:30px" 
+						inputmode="numeric" pattern="[0-9]{1,4}"
+						disabled="disabled"></td>
+					<td>Pump <input type="text" id="pwr_pump" maxlength="4" style="width:30px"
+						inputmode="numeric" pattern="[0-9]{1,4}"
+						disabled="disabled"></td>
+					<td>Idle <input type="text" id="pwr_idle" maxlength="4" style="width:30px"
+						inputmode="numeric" pattern="[0-9]{1,4}"
+						disabled="disabled"></td>
+					<td>Air <input type="text" id="pwr_air" maxlength="4" style="width:30px"
+						inputmode="numeric" pattern="[0-9]{1,4}"
+						disabled="disabled"></td>
+					<td>Jets <input type="text" id="pwr_jet" maxlength="4" style="width:30px"
+						inputmode="numeric" pattern="[0-9]{1,4}"
+						disabled="disabled"></td>
+				</tr>
+			</table>
+		</section>
+
+		<section>
 			<table>
 				<tr>
 					<td colspan="2" style="text-align:center">
@@ -161,6 +190,17 @@
 <script>
 setPins();	
 loadHardwareConfig();
+
+function onOverrideClick()
+{
+	let checked = document.getElementById("pwr_override").checked;
+	[...document.querySelectorAll("input[id^='pwr_']")]
+		.forEach((e) => {
+			if (e.type !== "checkbox") {
+				e.disabled = !checked;
+			}
+		})
+}
 
 function setPins()
 {
@@ -320,6 +360,20 @@ function loadHardwareConfig()
 			{
 				setPins();
 			}
+
+			// Set power levels if override enabled
+			if (json.pwr_levels.override) {
+				[...document.querySelectorAll("input[id^='pwr_']")]
+				.forEach((e) => {
+					if (e.type !== "checkbox") {
+						e.value = json.pwr_levels[e.id.slice(4)];
+					}
+				})
+				document.getElementById("pwr_override").checked = true;
+				onOverrideClick();
+			} else {
+				document.getElementById("pwr_override").checked = false;
+			}
 		}
 	}
 }
@@ -350,7 +404,17 @@ function saveHardwareConfig()
 			document.getElementById('pin6').value,
 			document.getElementById('pin7').value,
 			document.getElementById('pin8').value
-		]
+		],
+		'pwr_levels': 
+			[...document.querySelectorAll("input[id^='pwr_']")]
+				.reduce((acc, e) => {
+					if (e.type === "checkbox") {
+						acc[e.id.slice(4)] = e.checked;
+					} else {
+						acc[e.id.slice(4)] = e.value;
+					}
+					return acc;
+				}, {})
 	};
 	req.send(JSON.stringify(json));
 	console.log(JSON.stringify(json));

--- a/Code/lib/BWC_unified/bwc.cpp
+++ b/Code/lib/BWC_unified/bwc.cpp
@@ -1219,7 +1219,7 @@ bool BWC::_loadHardware(Models& cioNo, Models& dspNo, int pins[], std::optional<
         return false;
     }
     // DynamicJsonDocument doc(256);
-    StaticJsonDocument<272> doc;
+    StaticJsonDocument<512> doc;
     DeserializationError error = deserializeJson(doc, file);
     if (error) {
         // Serial.println(F("Failed to read settings.txt"));

--- a/Code/lib/BWC_unified/bwc.cpp
+++ b/Code/lib/BWC_unified/bwc.cpp
@@ -61,8 +61,9 @@ void BWC::setup(void){
     if(dsp != nullptr) delete dsp;
     Models ciomodel;
     Models dspmodel;
+    std::optional<Power> power_levels = {};
     
-    if(!_loadHardware(ciomodel, dspmodel, pins)){
+    if(!_loadHardware(ciomodel, dspmodel, pins, power_levels)){
         pins[0] = D1;
         pins[1] = D2;
         pins[2] = D3;
@@ -148,6 +149,9 @@ void BWC::setup(void){
         }
     }
     cio->setup(pins[0], pins[1], pins[2]);
+
+    cio->setPowerLevels(power_levels);
+    
     dsp->setup(pins[3], pins[4], pins[5], pins[6]);
     tempSensorPin = pins[7];
     hasjets = cio->getHasjets();
@@ -1170,17 +1174,17 @@ void BWC::_updateTimes(){
     if(_override_dsp_brt_timer > 0) _override_dsp_brt_timer -= elapsedtime_ms; //counts down to or below zero
 
     // watts, kWh today, total kWh
-    float heatingEnergy = (_heatingtime+_heatingtime_ms/1000)/3600.0 * cio->getPower().HEATERPOWER;
-    float pumpEnergy = (_pumptime+_pumptime_ms/1000)/3600.0 * cio->getPower().PUMPPOWER;
-    float airEnergy = (_airtime+_airtime_ms/1000)/3600.0 * cio->getPower().AIRPOWER;
-    float idleEnergy = (_uptime+_uptime_ms/1000)/3600.0 * cio->getPower().IDLEPOWER;
-    float jetEnergy = (_jettime+_jettime_ms/1000)/3600.0 * cio->getPower().JETPOWER;
+    float heatingEnergy = (_heatingtime+_heatingtime_ms/1000)/3600.0 * cio->getHeaterPower();
+    float pumpEnergy = (_pumptime+_pumptime_ms/1000)/3600.0 * cio->getPowerLevels().PUMPPOWER;
+    float airEnergy = (_airtime+_airtime_ms/1000)/3600.0 * cio->getPowerLevels().AIRPOWER;
+    float idleEnergy = (_uptime+_uptime_ms/1000)/3600.0 * cio->getPowerLevels().IDLEPOWER;
+    float jetEnergy = (_jettime+_jettime_ms/1000)/3600.0 * cio->getPowerLevels().JETPOWER;
     _energy_total_kWh = (heatingEnergy + pumpEnergy + airEnergy + idleEnergy + jetEnergy)/1000; //Wh -> kWh
-    _energy_power_W = cio->cio_states.heatred * cio->getPower().HEATERPOWER;
-    _energy_power_W += cio->cio_states.pump * cio->getPower().PUMPPOWER;
-    _energy_power_W += cio->cio_states.bubbles * cio->getPower().AIRPOWER;
-    _energy_power_W += cio->getPower().IDLEPOWER;
-    _energy_power_W += cio->cio_states.jets * cio->getPower().JETPOWER;
+    _energy_power_W = cio->cio_states.heatred * cio->getHeaterPower();
+    _energy_power_W += cio->cio_states.pump * cio->getPowerLevels().PUMPPOWER;
+    _energy_power_W += cio->cio_states.bubbles * cio->getPowerLevels().AIRPOWER;
+    _energy_power_W += cio->getPowerLevels().IDLEPOWER;
+    _energy_power_W += cio->cio_states.jets * cio->getPowerLevels().JETPOWER;
 
     _energy_daily_Ws += elapsedtime_ms * _energy_power_W / 1000.0;
     _energy_cost += _price * _energy_power_W / (1000.0 * 1000.0 * 3600.0); // money/kWh
@@ -1206,7 +1210,7 @@ void BWC::_updateTimes(){
 /* LOADERS  */
 /*          */
 
-bool BWC::_loadHardware(Models& cioNo, Models& dspNo, int pins[])
+bool BWC::_loadHardware(Models& cioNo, Models& dspNo, int pins[], std::optional<Power>& power_levels)
 {
     File file = LittleFS.open(F("/hwcfg.json"), "r");
     if (!file)
@@ -1243,6 +1247,21 @@ bool BWC::_loadHardware(Models& cioNo, Models& dspNo, int pins[])
         pins[i] = DtoGPIO[pins[i]];
     #endif
     }
+
+    const auto pwr_levels_json = doc[F("pwr_levels")];
+    if (pwr_levels_json[F("override")].as<bool>()) {
+        power_levels.emplace(
+            Power{
+                .HEATERPOWER_STAGE1 = pwr_levels_json[F("heater_stage1")].as<int>(),
+                .HEATERPOWER_STAGE2 = pwr_levels_json[F("heater_stage2")].as<int>(),
+                .PUMPPOWER = pwr_levels_json[F("pump")].as<int>(),
+                .AIRPOWER = pwr_levels_json[F("air")].as<int>(),
+                .IDLEPOWER = pwr_levels_json[F("idle")].as<int>(),
+                .JETPOWER = pwr_levels_json[F("jet")].as<int>(),
+            }
+        );
+    }
+
     return true;
 }
 

--- a/Code/lib/BWC_unified/bwc.h
+++ b/Code/lib/BWC_unified/bwc.h
@@ -14,6 +14,7 @@
 #include <LittleFS.h>
 #include <Ticker.h>
 #include <vector>
+#include <optional>
 #include "enums.h"
 #include "CIO_PRE2021.h"
 #include "CIO_2021.h"
@@ -106,7 +107,7 @@ class BWC {
         bool hasTempSensor = false;
 
     private:
-        bool _loadHardware(Models& cioNo, Models& dspNo, int pins[]);
+        bool _loadHardware(Models& cioNo, Models& dspNo, int pins[], std::optional<Power>& power_levels);
         bool _handlecommand(Commands cmd, int64_t val, const String& txt);
         void _handleCommandQ();
         void _loadSettings();

--- a/Code/lib/BWC_unified/enums.h
+++ b/Code/lib/BWC_unified/enums.h
@@ -108,11 +108,18 @@ enum Models: uint8_t
 
 struct Power
 {
-    int HEATERPOWER;
+    int HEATERPOWER_STAGE1;
+    int HEATERPOWER_STAGE2;
     int PUMPPOWER;
     int AIRPOWER;
     int IDLEPOWER;
     int JETPOWER;
+};
+
+struct HeaterStages
+{
+    bool stage1_on = false;
+    bool stage2_on = false;
 };
 
 struct sStates

--- a/Code/lib/cio/CIO_4W.h
+++ b/Code/lib/cio/CIO_4W.h
@@ -14,7 +14,6 @@ class CIO_4W : public CIO
     public:
         CIO_4W(){};
         virtual ~CIO_4W(){};
-        Power getPower(){return _power;}
         void setup(int cio_rx, int cio_tx, int dummy);
         void stop();
         void pause_all(bool action);
@@ -25,6 +24,7 @@ class CIO_4W : public CIO
         virtual bool getHasair() = 0;
         bool getSerialReceived() override;
         void setSerialReceived(bool txok) override;
+        void setPowerLevels(const std::optional<const Power>& power_levels) override;
 
     /*internal use*/
     protected:
@@ -44,7 +44,6 @@ class CIO_4W : public CIO
 
     private:
         uint64_t _prev_ms;
-        Power _power = {1900, 40, 800, 2, 400};
         SoftwareSerial *_cio_serial;
         uint8_t _heat_bitmask = 0;
         uint8_t _from_CIO_buf[7] = {};
@@ -67,5 +66,14 @@ class CIO_4W : public CIO
         bool _turn_off_pump_flag = false;
         bool _serialreceived = false;
         bool _readyToTransmit = false;
+
+        const Power _default_power_levels = {
+            .HEATERPOWER_STAGE1 = 950,
+            .HEATERPOWER_STAGE2 = 950,
+            .PUMPPOWER = 950,
+            .AIRPOWER = 950,
+            .IDLEPOWER = 950,
+            .JETPOWER = 950,
+        };
 };
 

--- a/Code/lib/cio/CIO_6W.h
+++ b/Code/lib/cio/CIO_6W.h
@@ -17,7 +17,6 @@ class CIO_6W : public CIO
     public:
         CIO_6W();
         virtual ~CIO_6W(){};
-        Power getPower(){return power;}
         void handleToggles();
         bool getHasgod() {return false;}
         virtual bool getHasjets() = 0;
@@ -29,10 +28,6 @@ class CIO_6W : public CIO
         void _qButton(sButton_queue_item item);
         void _handleButtonQ(void);
         void unlock();
-
-    /*These must be declared for the API to work*/
-    public:
-        Power power = {1900, 40, 800, 2, 400};
 
     public:
         uint8_t brightness;

--- a/Code/lib/cio/CIO_BASE.cpp
+++ b/Code/lib/cio/CIO_BASE.cpp
@@ -24,3 +24,17 @@ String CIO::debug()
     s += String(good_packets_count);
     return s;
 }
+
+int CIO::getHeaterPower()
+{
+    return
+        (_heater_stages.stage1_on ? 1:0) * _power_levels.HEATERPOWER_STAGE1 +
+        (_heater_stages.stage2_on ? 1:0) * _power_levels.HEATERPOWER_STAGE2;
+
+}
+
+void CIO::setPowerLevels(const std::optional<const Power>& power_levels) {
+    if(power_levels.has_value()) {
+        _power_levels = power_levels.value();
+    }
+}

--- a/Code/lib/cio/CIO_BASE.h
+++ b/Code/lib/cio/CIO_BASE.h
@@ -20,13 +20,16 @@ class CIO
         void setRawPayload(const std::vector<uint8_t>& pl);
         std::vector<uint8_t> getRawPayload();
         virtual String getModel() = 0;
-        virtual Power getPower() = 0;
         virtual bool getHasgod() = 0;
         virtual bool getHasjets() = 0;
         virtual bool getHasair() = 0;
         virtual bool getSerialReceived() {return false;} //"overridden" in CIO 4W
         virtual void setSerialReceived(bool txok) {}     //"overridden" in CIO 4W  
         String debug();
+        const Power& getPowerLevels() {return _power_levels;}
+        virtual void setPowerLevels(const std::optional<const Power>& power_levels);
+        void setHeaterStages(const HeaterStages& heater_stages) {_heater_stages = heater_stages;}
+        int getHeaterPower();
 
     public:
         sStates cio_states;
@@ -38,4 +41,18 @@ class CIO
     
     protected:
         std::vector<uint8_t> _raw_payload_from_cio = {0,0,0,0,0,0,0,0,0,0,0};
+
+    private:
+        Power _power_levels = {
+            .HEATERPOWER_STAGE1 = 1900,
+            .HEATERPOWER_STAGE2 = 0,
+            .PUMPPOWER = 40,
+            .AIRPOWER = 800,
+            .IDLEPOWER = 2,
+            .JETPOWER = 400,
+        };
+        HeaterStages _heater_stages = {
+            .stage1_on = true,
+            .stage2_on = true,
+        };
 };


### PR DESCRIPTION
This adds an option in the hardware configuration to override power usage for each element. With this, it is possible to better adjust power usage statistics for non standard models, especially 110V based ones.