### PR TITLE
Add support for custom environments

### DIFF
--- a/Code/.gitignore
+++ b/Code/.gitignore
@@ -3,3 +3,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+custom_envs/

--- a/Code/platformio.ini
+++ b/Code/platformio.ini
@@ -12,6 +12,8 @@
 src_dir = src
 data_dir = datazip
 ; default_envs = esp32
+extra_configs =
+    custom_envs/*.ini
 
 [env:nodemcuv2]
 platform = espressif8266@^4


### PR DESCRIPTION
Add extra_configs = custom_envs/*.ini to platformio.ini Add custom_envs/ to .gitignore

Add new environment by adding ini files to custom_envs folder, eg d1_mini.ini:
[env:d1_mini]
extends = env:nodemcuv2
board = d1_mini