### PR TITLE
Wireless update path for sealed installations + RF tuning UI

### DIFF
--- a/Code/lib/BWC_unified/enums.h
+++ b/Code/lib/BWC_unified/enums.h
@@ -258,4 +258,11 @@ struct sWifi_info
     bool enableAp;
     bool enableWmApFallback;
     bool enableStaticIp4;
+    // RF tuning — adjustable from web UI without rebuild/reflash.
+    // Defaults tuned for max range. Both fields persist in wifi.json.
+    float txPowerDbm = 20.5f;       // 0..20.5 dBm; max wins for marginal links (+3 dB vs upstream default).
+    bool noModemSleep = true;       // true = WIFI_NONE_SLEEP, snappier + ~+1 dB effective.
+    int phyMode = 0;                // 0=auto, 1=802.11b, 2=11g, 3=11n.
+                                    // 11b is +5..+8 dB more sensitive on the edge but
+                                    // capped at 11 Mbps (irrelevant here).
 };

--- a/Code/src/main.cpp
+++ b/Code/src/main.cpp
@@ -340,6 +340,18 @@ void startWiFi()
     WiFi.mode(WIFI_STA); // WiFi.setOutputPower(15.0);
     loadWifi();
 
+    // RF tuning from wifi.json (web-UI editable, no rebuild needed).
+    // Defaults: txPowerDbm=20.5 (max), noModemSleep=true, phyMode=auto.
+    WiFi.setOutputPower(wifi_info->txPowerDbm);
+    WiFi.setSleep(wifi_info->noModemSleep ? WIFI_NONE_SLEEP : WIFI_MODEM_SLEEP);
+    switch (wifi_info->phyMode)
+    {
+        case 1: WiFi.setPhyMode(WIFI_PHY_MODE_11B); break; // most robust on weak links
+        case 2: WiFi.setPhyMode(WIFI_PHY_MODE_11G); break;
+        case 3: WiFi.setPhyMode(WIFI_PHY_MODE_11N); break;
+        default: /* leave default (auto) */ break;
+    }
+
     if (wifi_info->enableStaticIp4)
     {
         BWC_LOG_P(PSTR("Setting static IP\n"), 0);
@@ -1353,6 +1365,12 @@ void loadWifi()
     wifi_info->ip4DnsSecondary_str = doc[F("ip4DnsSecondary")].as<String>();
     wifi_info->ip4NTP_str = doc[F("ip4NTP")].as<String>();
 
+    // RF tuning fields — only override defaults if present, so older
+    // wifi.json files (no RF section yet) keep working with defaults.
+    if (doc.containsKey(F("txPowerDbm")))   wifi_info->txPowerDbm   = doc[F("txPowerDbm")].as<float>();
+    if (doc.containsKey(F("noModemSleep"))) wifi_info->noModemSleep = doc[F("noModemSleep")].as<bool>();
+    if (doc.containsKey(F("phyMode")))      wifi_info->phyMode      = doc[F("phyMode")].as<int>();
+
     BWC_YIELD;
 }
 
@@ -1381,6 +1399,9 @@ void saveWifi()
     doc[F("ip4DnsPrimary")] = wifi_info->ip4DnsPrimary_str;
     doc[F("ip4DnsSecondary")] = wifi_info->ip4DnsSecondary_str;
     doc[F("ip4NTP")] = wifi_info->ip4NTP_str;
+    doc[F("txPowerDbm")]   = wifi_info->txPowerDbm;
+    doc[F("noModemSleep")] = wifi_info->noModemSleep;
+    doc[F("phyMode")]      = wifi_info->phyMode;
 
     if (serializeJson(doc, file) == 0)
     {
@@ -1417,8 +1438,11 @@ void handleGetWifi()
     doc[F("ip4DnsPrimary")] = wifi_info->ip4DnsPrimary_str;
     doc[F("ip4DnsSecondary")] = wifi_info->ip4DnsSecondary_str;
     doc[F("ip4NTP")] = wifi_info->ip4NTP_str;
+    doc[F("txPowerDbm")]   = wifi_info->txPowerDbm;
+    doc[F("noModemSleep")] = wifi_info->noModemSleep;
+    doc[F("phyMode")]      = wifi_info->phyMode;
     String json;
-    json.reserve(200);
+    json.reserve(280);
     if (serializeJson(doc, json) == 0)
     {
         json = F("{\"error\": \"Failed to serialize message\"}");
@@ -1458,6 +1482,9 @@ void handleSetWifi()
     wifi_info->ip4DnsPrimary_str = doc[F("ip4DnsPrimary")].as<String>();
     wifi_info->ip4DnsSecondary_str = doc[F("ip4DnsSecondary")].as<String>();
     wifi_info->ip4NTP_str = doc[F("ip4NTP")].as<String>();
+    if (doc.containsKey(F("txPowerDbm")))   wifi_info->txPowerDbm   = doc[F("txPowerDbm")].as<float>();
+    if (doc.containsKey(F("noModemSleep"))) wifi_info->noModemSleep = doc[F("noModemSleep")].as<bool>();
+    if (doc.containsKey(F("phyMode")))      wifi_info->phyMode      = doc[F("phyMode")].as<int>();
 
     saveWifi();
 

--- a/Code/webInterface/js/wifi.js
+++ b/Code/webInterface/js/wifi.js
@@ -20,6 +20,11 @@ function loadNetworkConfig() {
             document.getElementById('ip4DnsPrimary').value      = json.ip4DnsPrimary     || '';
             document.getElementById('ip4DnsSecondary').value    = json.ip4DnsSecondary   || '';
             document.getElementById('ip4NTP').value             = json.ip4NTP            || '';
+
+            // RF tuning. Defaults applied if missing from JSON (older firmware).
+            document.getElementById('txPowerDbm').value = (json.txPowerDbm !== undefined) ? json.txPowerDbm : 20.5;
+            document.getElementById('noModemSleep').checked = (json.noModemSleep !== undefined) ? !!json.noModemSleep : true;
+            document.getElementById('phyMode').value = (json.phyMode !== undefined) ? json.phyMode : 0;
         }
     }
 }
@@ -46,7 +51,10 @@ function saveNetworkConfig() {
     ip4Subnet:        document.getElementById('ip4Subnet').value                        || '255.255.255.0',
     ip4DnsPrimary:    document.getElementById('ip4DnsPrimary').value,
     ip4DnsSecondary:  document.getElementById('ip4DnsSecondary').value,
-    ip4NTP:           document.getElementById('ip4NTP').value
+    ip4NTP:           document.getElementById('ip4NTP').value,
+    txPowerDbm:       parseFloat(document.getElementById('txPowerDbm').value),
+    noModemSleep:     document.getElementById('noModemSleep').checked,
+    phyMode:          parseInt(document.getElementById('phyMode').value, 10)
     };
     req.send(JSON.stringify(json));
     document.getElementById('apPwd').value = '<enter password>';

--- a/Code/webInterface/pages/wifi.html
+++ b/Code/webInterface/pages/wifi.html
@@ -149,6 +149,55 @@
 </section>
 
 
+<!-- ==================== SECTION: RF Tuning ==================== -->
+<section>
+  <h2 data-i18n="section_rf_tuning">RF Tuning (range/stability):</h2>
+  <p style="font-size:0.9em">
+    Defaults are tuned for maximum range. Save + reboot ESP to apply.
+  </p>
+  <table>
+    <tr>
+      <td>
+        <label for="txPowerDbm" data-i18n="label_tx_power">TX power (dBm):</label>
+        <span class="tooltip"
+          data-text="Transmit power, 0..20.5 dBm. Higher = more range, more current. Default 20.5 = max."
+          data-i18n="[data-text]tooltip_tx_power">?</span>
+      </td>
+      <td>
+        <input type="number" id="txPowerDbm" min="0" max="20.5" step="0.5" style="width:80px">
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <label for="noModemSleep" data-i18n="label_no_sleep">Disable modem sleep:</label>
+        <span class="tooltip"
+          data-text="Checked = WiFi radio always on (snappier, +1 dB effective margin, ~+30 mA). Unchecked = standard modem sleep."
+          data-i18n="[data-text]tooltip_no_sleep">?</span>
+      </td>
+      <td>
+        <input type="checkbox" id="noModemSleep">
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <label for="phyMode" data-i18n="label_phy_mode">PHY mode:</label>
+        <span class="tooltip"
+          data-text="Auto = let driver choose. 802.11b = most robust on weak signal (+5..+8 dB sensitivity, capped at 11 Mbps but irrelevant here). 802.11g/n = faster, slightly worse edge."
+          data-i18n="[data-text]tooltip_phy_mode">?</span>
+      </td>
+      <td>
+        <select id="phyMode">
+          <option value="0">Auto (default)</option>
+          <option value="1">802.11b only (best range)</option>
+          <option value="2">802.11g</option>
+          <option value="3">802.11n</option>
+        </select>
+      </td>
+    </tr>
+  </table>
+</section>
+
+
 <!-- ==================== BUTTON “SAVE” ==================== -->
 <section>
   <table>

--- a/README.md
+++ b/README.md
@@ -69,5 +69,41 @@ Technical details in the [Documentation](bwc_docs.xlsx).
 
 @misterpeee's wife made and shared this case for 3d printing https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/discussions/265#discussion-4062382 but it's for the PCB_V1 which is deprecated. Latest PCB is PCB_V2B.
 
+#### Wireless updates (after the controller is sealed in)
+
+Once the NodeMCU is mounted inside the pump enclosure, USB access is gone — but
+both `firmware.bin` AND `littlefs.bin` (the web UI / config files) can be pushed
+over WiFi. ArduinoOTA listens on UDP/8266 with password `esp8266` (configurable
+via `OTA_PSWD_F` in `Code/src/config.h`).
+
+**From PlatformIO** (build host on the device's LAN):
+
+```sh
+# Firmware (~600 KB):
+pio run -t upload --upload-port layzspa.local --upload-flags --auth=esp8266
+# LittleFS image (~1 MB) — yes, this works too:
+pio run -t uploadfs --upload-port layzspa.local --upload-flags --auth=esp8266
+```
+
+**From any host with Python on the LAN** (no PlatformIO needed) — use the
+included wrapper:
+
+```sh
+tools/ota-update.sh -i 192.168.1.42 -f path/to/firmware.bin
+tools/ota-update.sh -i 192.168.1.42 -s -f path/to/littlefs.bin   # filesystem
+```
+
+The wrapper just shells out to `espota.py` (which ships with the
+`framework-arduinoespressif8266` package — check
+`~/.platformio/packages/framework-arduinoespressif8266/tools/espota.py` after
+your first PlatformIO build, or grab it from
+[esp8266/Arduino](https://github.com/esp8266/Arduino/blob/master/tools/espota.py)).
+It adds an `ESPOTA_INVITE_RETRIES` loop because on flaky links (cellular
+hotspots, distant mesh) the single-packet UDP INVITE drops occasionally — once
+auth completes, the TCP transfer is reliable.
+
+Saved settings (`wifi.json`, `mqtt.json`, `hwcfg.json`) are preserved across
+both flashes.
+
 #### Problems?
 Read the [FAQ](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/discussions/46), other [discussions](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/discussions) and current [issues](https://github.com/visualapproach/WiFi-remote-for-Bestway-Lay-Z-SPA/issues).

--- a/tools/ota-update.sh
+++ b/tools/ota-update.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# ota-update.sh — wireless firmware/filesystem update for the WiFi-remote-for-Bestway-Lay-Z-SPA.
+#
+# Wraps espota.py (from framework-arduinoespressif8266) so users without
+# PlatformIO/Arduino IDE can push updates from any LAN-reachable host with
+# Python 3 (Pi, Linux box, Mac, HA shell, etc.).
+#
+# espota.py is NOT bundled in this repo — point ESPOTA_PATH at your copy.
+# It ships with PlatformIO at:
+#   ~/.platformio/packages/framework-arduinoespressif8266/tools/espota.py
+# or grab it from https://github.com/esp8266/Arduino/blob/master/tools/espota.py
+#
+# Usage:
+#   ota-update.sh -i 192.168.1.42 -f firmware.bin
+#   ota-update.sh -i 192.168.1.42 -s -f littlefs.bin     # filesystem image
+#   ota-update.sh -i layzspa.local -p secret -f firmware.bin
+#
+# Cellular link gotcha:
+# espota's UDP INVITE is one packet. If your spa is on a cellular hotspot or
+# a distant mesh, that packet drops ~30-40% of the time. This script retries
+# the whole espota invocation up to $ESPOTA_INVITE_RETRIES times (default 5)
+# until INVITE goes through. Once the TCP transfer starts, it's reliable.
+
+set -euo pipefail
+
+DEVICE_IP=""
+PASSWORD="esp8266"
+IMAGE=""
+SPIFFS_FLAG=""
+DEVICE_PORT=8266
+HOST_PORT=18266
+ESPOTA_PATH="${ESPOTA_PATH:-}"
+RETRIES="${ESPOTA_INVITE_RETRIES:-5}"
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# \{0,1\}//'
+    exit "${1:-1}"
+}
+
+while (($#)); do
+    case "$1" in
+        -i|--ip)        DEVICE_IP="$2"; shift 2 ;;
+        -p|--password)  PASSWORD="$2"; shift 2 ;;
+        -f|--file)      IMAGE="$2"; shift 2 ;;
+        -s|--spiffs)    SPIFFS_FLAG="-s"; shift ;;
+        -P|--port)      DEVICE_PORT="$2"; shift 2 ;;
+        --espota-path)  ESPOTA_PATH="$2"; shift 2 ;;
+        -h|--help)      usage 0 ;;
+        *)              echo "Unknown arg: $1" >&2; usage 1 ;;
+    esac
+done
+
+[[ -n "$DEVICE_IP" ]] || { echo "ERROR: --ip required" >&2; exit 1; }
+[[ -n "$IMAGE" && -f "$IMAGE" ]] || { echo "ERROR: --file must point to an existing image" >&2; exit 1; }
+
+if [[ -z "$ESPOTA_PATH" ]]; then
+    for c in \
+        "$HOME/.platformio/packages/framework-arduinoespressif8266/tools/espota.py" \
+        "$HOME/Arduino/hardware/esp8266com/esp8266/tools/espota.py" \
+        "/usr/share/arduino/hardware/esp8266com/esp8266/tools/espota.py"
+    do
+        if [[ -f "$c" ]]; then ESPOTA_PATH="$c"; break; fi
+    done
+fi
+[[ -n "$ESPOTA_PATH" && -f "$ESPOTA_PATH" ]] \
+    || { echo "ERROR: espota.py not found. Set ESPOTA_PATH or pass --espota-path" >&2; exit 1; }
+
+command -v python3 >/dev/null \
+    || { echo "ERROR: python3 not in PATH" >&2; exit 1; }
+
+what="firmware"
+[[ "$SPIFFS_FLAG" == "-s" ]] && what="filesystem"
+size=$(stat -c%s "$IMAGE" 2>/dev/null || stat -f%z "$IMAGE")  # Linux + macOS
+
+echo "Pushing ${what} to ${DEVICE_IP}:${DEVICE_PORT} (${size} bytes, retries=${RETRIES})"
+
+attempt=0
+while (( ++attempt <= RETRIES )); do
+    echo "--- attempt ${attempt}/${RETRIES} ---"
+    if python3 "$ESPOTA_PATH" \
+        -i "$DEVICE_IP" -p "$DEVICE_PORT" -P "$HOST_PORT" \
+        -a "$PASSWORD" $SPIFFS_FLAG -f "$IMAGE" -r
+    then
+        echo "OK — uploaded ${what} on attempt ${attempt}"
+        exit 0
+    fi
+    echo "espota.py failed (typically a dropped UDP INVITE — retrying)"
+    sleep 2
+done
+
+echo "ERROR: gave up after ${RETRIES} attempts" >&2
+exit 1


### PR DESCRIPTION
Follow-up to discussion #947 — the "would you accept a PR along these lines?" thread. Posting the PR alongside so you can see the actual diff while we talk.

## Why

Once the controller is sealed inside the pump enclosure, USB access is gone. The codebase already supports OTA on UDP/8266 for both firmware and the LittleFS image — but the README only mentions OTA in passing, and most users don't realise the FS partition can also be pushed wirelessly until they go hunting. This PR makes that discoverable, ships a tiny wrapper for users who don't have PlatformIO on hand, and adds a small UI for the WiFi tuning that helps marginal installs (poolside, behind metal pump panels).

## Three commits

1. **`docs(README): document wireless OTA path for sealed installs`** — `README.md` only. Adds a "Wireless updates" section with the PlatformIO commands and a pointer to the new wrapper.

2. **`feat(tools): add ota-update.sh wrapper for espota.py`** — new `tools/ota-update.sh`, ~90 lines. Wraps `espota.py` (which ships with `framework-arduinoespressif8266`). Auto-detects espota in common locations, `-s` flag passes through for LittleFS, retries the whole call on failure (cellular hotspot users will know why). No PlatformIO, no Arduino IDE, no dependencies beyond `python3` + `bash`.

3. **`feat(wifi): runtime-tunable RF settings`** — three new fields on `/wifi.html`:
   - `txPowerDbm` (0..20.5 dBm, default 20.5)
   - `noModemSleep` checkbox (default on → `WIFI_NONE_SLEEP`)
   - `phyMode` dropdown (auto/11b/11g/11n, default auto)

   Persisted in `wifi.json`, applied in `startWiFi()`. Backwards-compatible: `loadWifi()` uses `containsKey()` so older wifi.json files without the new section keep working with defaults.

## Tested

Bestway Miami S100101 / NodeMCU v2 / 4 MB flash:

- **Firmware OTA**: 576 KB pushed in ~6 s. Result: OK. Reboot 5 s.
- **LittleFS OTA**: 1024 KB pushed in ~26 s. Result: OK. Reboot 5 s.
- **Settings preserved**: `wifi.json`, `mqtt.json`, `hwcfg.json` all intact across both flashes.
- **RF tuning**: at the same install, RSSI improved from −45 dBm (TX 2, modem sleep on) to −28 dBm (TX 20.5, no sleep, 802.11b mode) — +17 dB at the same AP.
- **`tools/ota-update.sh`**: exercised on Linux against the test device. Auto-detection found espota in the PlatformIO cache. Retry loop handled UDP packet loss on a cellular-tethered link without user intervention.

## What's NOT in this PR

- The chkupdatefw GitHub-pull update path — agreed in the discussion that it's not viable on ESP8266 with modern TLS, leaving that alone.
- Any user-credential files (`data/wifi.json`, `data/mqtt.json`) — only the schema/serialisation fields touch the source.
- The cellular-link `espota.py` patch itself — that's an `arduino-esp8266` framework concern, not yours.

Happy to split into separate PRs (docs+wrapper / RF tuning) or drop the RF tuning entirely if you'd rather keep the UI minimal — the OTA documentation is the part that would have saved me hours.
