### PR TITLE
Defer HA discovery publish out of the MQTT connect handshake

### DIFF
--- a/Code/src/main.cpp
+++ b/Code/src/main.cpp
@@ -165,6 +165,23 @@ void loop()
                 send_mqtt_cfg_needed = false;
                 sendMQTTConfig();
             }
+            // Send HA discovery 5s after each (re)connect for connection stability
+            static int ha_sent_for_count = 0;
+            static unsigned long ha_pending_since = 0;
+            if (ha_sent_for_count < mqtt_connect_count)
+            {
+                if (ha_pending_since == 0) ha_pending_since = millis();
+                if (millis() - ha_pending_since >= 5000UL)
+                {
+                    ha_pending_since = 0;
+                    ha_sent_for_count = mqtt_connect_count;
+                    BWC_LOG_P(PSTR("MQTT > Sending HA discovery\n"),0);
+                    mqttClient->setBufferSize(1536);
+                    setupHA();
+                    mqttClient->setBufferSize(512);
+                    mqttClient->loop();
+                }
+            }
         }
 
         if (checkNTP_flag)
@@ -2141,12 +2158,19 @@ void mqttConnect()
     {
         return;
     }
+    String mqttClientId = mqtt_info->mqttClientId;
+    if (mqttClientId.isEmpty())
+    {
+        mqttClientId = String(DEVICE_NAME) + "_" + String(ESP.getChipId(), HEX);
+        BWC_LOG_P(PSTR("MQTT > Client ID auto: %s\n"), mqttClientId.c_str());
+    }
+
     BWC_LOG_P(PSTR("MQTT > connecting\n"), 0);
 
     // Serial.print(F("MQTT > Connecting ... "));
     // We'll connect with a Retained Last Will that updates the 'Status' topic with "Dead" when the device goes offline...
     if (mqttClient->connect(
-            mqtt_info->mqttClientId.c_str(),                           // client_id : the client ID to use when connecting to the server->
+            mqttClientId.c_str(),                           // client_id : the client ID to use when connecting to the server->
             mqtt_info->mqttUsername.c_str(),                           // username : the username to use. If NULL, no username or password is used (const char[])
             mqtt_info->mqttPassword.c_str(),                           // password : the password to use. If NULL, no password is used (const char[])setupHA
             (String(mqtt_info->mqttBaseTopic) + F("/Status")).c_str(), // willTopic : the topic to be used by the will message (const char[])
@@ -2183,22 +2207,16 @@ void mqttConnect()
         bwc->getButtonName(buttonname);
         mqttClient->publish((String(mqtt_info->mqttBaseTopic) + F("/button")).c_str(), buttonname.c_str(), true);
         mqttClient->loop();
-        sendMQTT();
-        BWC_LOG_P(PSTR("MQTT > Sending HA discovery"), 0);
-        mqttClient->setBufferSize(1536);
-        setupHA();
         mqttClient->setBufferSize(512);
+        sendMQTT();
         mqttClient->loop();
-        // Serial.println(F("MQTT Sending config"));
-        // sendMQTTConfig();    // Stack smashing if doing this here :-(
         send_mqtt_cfg_needed = true;
         BWC_LOG_P(PSTR("MQTT > connect done\n"), 0);
 #endif
     }
     else
     {
-        // Serial.print(F("failed, Return Code = "));
-        // Serial.println(mqttClient->state()); // states explained in webSocket->js
+        BWC_LOG_P(PSTR("MQTT > connect failed, state=%d\n"), mqttClient->state());
     }
     BWC_YIELD;
 }


### PR DESCRIPTION
## Problem

`mqttConnect()` currently calls `setupHA()` (a large synchronous MQTT publish
burst for Home Assistant discovery) inline, right after the
`mqttClient->connect()` handshake succeeds. Publishing a big payload
synchronously at that exact point in the connection lifecycle can destabilize
the connection — this is the same class of issue already flagged in the
existing code for `sendMQTTConfig()`:

```cpp
// Serial.println(F("MQTT Sending config"));
// sendMQTTConfig();    // Stack smashing if doing this here :-(
```

`sendMQTTConfig()` was already deferred via `send_mqtt_cfg_needed` /
`loop()`. `setupHA()` wasn't — it's the larger of the two payloads and the
most likely to reproduce the same instability, especially on ESP8266.

## Fix

Apply the same deferred-execution pattern already used for
`sendMQTTConfig()` to `setupHA()`:

- Remove the synchronous `setupHA()` call from the success branch of
  `mqttConnect()`.
- In `loop()`, track the last connection count for which discovery was sent
  (`ha_sent_for_count` vs `mqtt_connect_count`) and trigger `setupHA()` once,
  5 seconds after each (re)connection, once the MQTT link has had time to
  settle.

## Also included (small, related robustness fixes in the same function)

- **MQTT client ID fallback**: if `mqttClientId` isn't configured, auto-generate
  one from the device name + chip ID (`layzspa_<chipid>`), instead of
  connecting with an empty/default client ID that could collide between
  multiple devices sharing the default config.
- **Failure logging**: log `mqttClient->state()` when the connect handshake
  fails, instead of a silent no-op (the previous logging was commented out).

## Testing

- `pio run -e nodemcuv2` — SUCCESS.
- Running in production on my own ESP8266 unit, as part of a larger fork that
  also includes some HA discovery/energy-tracking changes I'm planning to
  submit as a separate PR.